### PR TITLE
chore: change dependabot schedule to hourly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,25 +6,29 @@ updates:
     directory: "/"
     open-pull-requests-limit: 100
     schedule:
-      interval: "daily"
+      interval: "cron"
+      cronjob: "0 * * * *"
 
   - package-ecosystem: "npm"
     target-branch: "master"
     directory: "/"
     open-pull-requests-limit: 100
     schedule:
-      interval: "daily"
+      interval: "cron"
+      cronjob: "0 * * * *"
 
   - package-ecosystem: "nuget"
     target-branch: "dev"
     directory: "/"
     open-pull-requests-limit: 100
     schedule:
-      interval: "daily"
+      interval: "cron"
+      cronjob: "0 * * * *"
 
   - package-ecosystem: "npm"
     target-branch: "dev"
     directory: "/"
     open-pull-requests-limit: 100
     schedule:
-      interval: "daily"
+      interval: "cron"
+      cronjob: "0 * * * *"


### PR DESCRIPTION
Changes dependabot schedule from `daily` to hourly using `interval: "cron"` with `cronjob: "0 * * * *"`.