### PR TITLE
Remove 'NEVER define public interfaces in Infrastructure' rule

### DIFF
--- a/.github/instructions/architecture.instructions.md
+++ b/.github/instructions/architecture.instructions.md
@@ -1196,7 +1196,6 @@ A: No. Presentation calls Interfaces/Inbound only. Create a service in Applicati
 - NEVER use static service locator patterns
 - NEVER hardcode connection strings or URLs in Application
 - NEVER use `if (type == X)` branching in Application layer
-- NEVER define public interfaces in Infrastructure layer that other layers depend on
 - NEVER implement Interfaces/Inbound in Infrastructure layer
 - NEVER implement Interfaces/Outbound in Application layer
 - NEVER call Interfaces/Outbound directly from Presentation layer


### PR DESCRIPTION
## Summary

Removes the rule "NEVER define public interfaces in Infrastructure layer that other layers depend on" from `architecture.instructions.md`.

## Reason

This rule conflicts with .NET DI requirements. When Infrastructure interfaces (e.g., `IEFCoreEntityConfiguration`, `IEFCoreDatabaseBootstrap`) are used as constructor parameters in types resolved by DI (such as `DbContext` subclasses), the DI container requires those parameter types to be `public`. Making them `internal` causes runtime resolution failures.

The rule is impractical because Infrastructure projects legitimately need public interfaces for:
- DbContext constructor parameters resolved by DI
- Cross-infrastructure project contracts
- Extension point interfaces consumed by other Infrastructure projects

## Change

- Removed line 1199: `- NEVER define public interfaces in Infrastructure layer that other layers depend on`