### PR TITLE
fix: allow Infrastructure to call Application internal interfaces

### DIFF
--- a/.github/instructions/architecture.instructions.md
+++ b/.github/instructions/architecture.instructions.md
@@ -394,7 +394,7 @@ Interfaces/Outbound:
 Interfaces (without subfolder):
 - Are internal abstractions within Application layer
 - Are implemented by Application* services
-- MAY be called by Application* only
+- MAY be called by Application* and Infrastructure* only
 - MUST NOT be called by Presentation
 - Examples: `IDomainEventDispatcher`, `IDomainEventHandler`, `IOfflineSyncManager`
 
@@ -1196,6 +1196,7 @@ A: No. Presentation calls Interfaces/Inbound only. Create a service in Applicati
 - NEVER use static service locator patterns
 - NEVER hardcode connection strings or URLs in Application
 - NEVER use `if (type == X)` branching in Application layer
+- NEVER define public interfaces in Infrastructure layer that other layers depend on
 - NEVER implement Interfaces/Inbound in Infrastructure layer
 - NEVER implement Interfaces/Outbound in Application layer
 - NEVER call Interfaces/Outbound directly from Presentation layer


### PR DESCRIPTION
## Summary

Fix inconsistency in `Application/Interfaces/` (internal, no subfolder) access rule.

### Problem

The **prose** in the "Interfaces/ (Internal)" section stated:
> MAY be called by Application* only

But the **Interface Access Rules table** already listed:
> `Application/Interfaces/` | Application*, Infrastructure* | Application*

The codebase itself already violates the prose rule — `InMemoryWeatherForecastUnitOfWork` uses `IDomainEventDispatcher` from `Application.Shared.Interfaces`.

### Fix

Updated the prose to match the table:

```diff
- MAY be called by Application* only
+ MAY be called by Application* and Infrastructure* only
```

### Rationale

Infrastructure legitimately needs to consume Application-internal abstractions that are:
- **Implemented by Application** (not Outbound — wrong implementor)
- **Not meant for Presentation** (not Inbound — too broad)

Examples: `IDomainEventDispatcher` (used by UnitOfWork adapters), `IAuthorizedHttpClientFactory`, correlation/audit utilities.

### Updated Rule

| Interface Location | Who Can Use | Who Implements |
|----|----|----|
| `Application/Interfaces/Inbound/` | Any layer | Application* |
| `Application/Interfaces/Outbound/` | Application*, Infrastructure* | Infrastructure* |
| `Application/Interfaces/` | **Application*, Infrastructure*** | Application* |

Presentation still MUST NOT call internal interfaces.