### PR TITLE
Add AGENT_INIT.md and AGENT_RESUME.md session guides

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,6 +16,11 @@ When updating process docs, update the `.github/instructions/*` files instead of
 - UI test practices: `.github/instructions/ui-test-practices.instructions.md`
 - Rule style: `.github/instructions/rule-style.instructions.md`
 
+## Session Guides
+
+- New project initialization: `AGENT_INIT.md`
+- Existing project conversion: `AGENT_RESUME.md`
+
 ## Quick Links
 
 - Build entrypoints: `build.ps1`, `build.cmd`, `build.sh`

--- a/AGENT_INIT.md
+++ b/AGENT_INIT.md
@@ -1,0 +1,653 @@
+# Initialize ApplicationBuilderHelpers C# Project
+
+You are initializing a C# project using the **ApplicationBuilderHelpers** framework — a dependency injection and application lifecycle framework built on clean architecture principles. It provides `ApplicationDependency` lifecycle management, command hierarchy with CLI option parsing, multi-source configuration with `@ref:` chains, build-time encrypted embedded config, source-generated build constants, structured logging, and a middleware pipeline.
+
+Refer to the [ApplicationBuilderHelpers](https://github.com/nicenemo/ApplicationBuilderHelpers) repository for the NuGet package and core documentation. Use this template repository as the reference implementation.
+
+---
+
+## Step 1: Install the Rules and Documentation First
+
+Before creating any application file or running any command, install the project's rule set. These rules dictate folder structure, naming, layering, lifetimes, and prohibited patterns. Every step that follows depends on them.
+
+Clone this template repository into a temporary directory:
+
+```bash
+git clone https://github.com/Kiryuumaru/ApplicationBuilderHelpersTemplate.git /tmp/abht_source
+```
+
+Copy the agent instruction files into the project:
+
+```bash
+mkdir -p .github/instructions
+cp /tmp/abht_source/.github/instructions/*.md .github/instructions/
+```
+
+Copy the AGENTS.md into the project:
+
+```bash
+cp /tmp/abht_source/AGENTS.md .
+```
+
+---
+
+## Step 2: Read All Rules End-to-End
+
+Read every file in `.github/instructions/` before writing any code. Treat them as MUST/NEVER constraints, not suggestions:
+
+- `project-context.instructions.md` — terminology, project status, breaking-change policy
+- `rule-style.instructions.md` — how rules are written
+- `architecture.instructions.md` — layering, folder structure, DI lifetimes, ports/adapters, ApplicationDependency, ServiceCollectionExtensions, ConfigurationExtensions, commands, workers, naming, prohibited patterns
+- `code-quality.instructions.md` — nullable handling, commenting, constructors, fix hygiene
+- `documentation.instructions.md` — when to update docs
+- `workflow.instructions.md` — build/test commands, pre-commit checks
+- `agent-terminal.instructions.md` — terminal usage rules (no `&&`, `|`, `;`, redirections)
+- `ui-test-practices.instructions.md` — test conventions, assertions, no `Task.Delay`
+
+---
+
+## Step 3: Plan the Structure From the Rules
+
+Using the rules from Step 2, design the project layout BEFORE writing files. The architecture rules require a layered structure:
+
+```
+<project_root>/
+├── .github/
+│   └── instructions/                  <- already copied in Step 1
+├── AGENTS.md                          <- already copied in Step 1
+├── src/
+│   ├── Domain/                        <- pure business logic, no I/O
+│   │   ├── Domain.cs                  <- ApplicationDependency
+│   │   ├── Domain.csproj
+│   │   ├── Shared/                    <- base interfaces, models, exceptions
+│   │   │   ├── Interfaces/           <- IUnitOfWork, IAggregateRoot, IDomainEvent, IEntity
+│   │   │   ├── Models/               <- Entity, AggregateRoot, ValueObject, DomainEvent
+│   │   │   ├── Exceptions/           <- DomainException, EntityNotFoundException, ValidationException
+│   │   │   ├── Constants/            <- EmptyCollections, shared constants
+│   │   │   └── Extensions/
+│   │   └── {Feature}/                <- entities, value objects, events, domain services, repository/UoW interfaces
+│   ├── Domain.SourceGenerators/       <- source generators (BuildConstantsGenerator)
+│   │   └── Domain.SourceGenerators.csproj
+│   ├── Application/                   <- interfaces, services, workers, event handlers
+│   │   ├── Application.cs             <- ApplicationDependency
+│   │   ├── Application.csproj
+│   │   └── {Feature}/
+│   │       ├── Interfaces/
+│   │       │   ├── Inbound/          <- I{Feature}Service (called by Presentation)
+│   │       │   └── Outbound/         <- I{External}Provider (called by Application)
+│   │       ├── Services/
+│   │       ├── Workers/
+│   │       ├── EventHandlers/
+│   │       ├── Models/
+│   │       └── Extensions/
+│   ├── Infrastructure.{Provider}/     <- adapters, repositories
+│   │   ├── {Provider}Infrastructure.cs <- ApplicationDependency
+│   │   ├── {Provider}.Infrastructure.csproj
+│   │   ├── Adapters/
+│   │   ├── Repositories/
+│   │   └── Extensions/
+│   ├── Presentation/                  <- shared command base, contracts, components
+│   │   ├── Presentation.csproj
+│   │   └── Commands/
+│   │       └── BaseCommand.cs
+│   └── Presentation.Cli/              <- executable composition root
+│       ├── Presentation.Cli.csproj
+│       ├── Program.cs                 <- ONLY file that imports from Infrastructure
+│       └── Commands/
+│           └── MainCommand.cs
+├── tests/
+│   ├── Domain.UnitTests/
+│   └── Application.UnitTests/
+├── Directory.Build.targets            <- auto-wires BuildConstantsGenerator, embedded config
+├── global.json                        <- SDK version pinning
+└── ApplicationBuilderHelpersTemplate.slnx
+```
+
+For a minimal starter, only `Domain`, `Application`, `Presentation`, and `Presentation.Cli` are required. Infrastructure projects are added as data access or external service needs arrive.
+
+---
+
+## Step 4: Create global.json
+
+Create `global.json` at the project root to pin the .NET SDK version:
+
+```json
+{
+  "sdk": {
+    "version": "10.0.300",
+    "rollForward": "latestFeature"
+  }
+}
+```
+
+Run `dotnet --list-sdks` to find the installed version and adjust accordingly. Use `latestFeature` roll-forward for flexibility within the same feature band.
+
+---
+
+## Step 5: Create the Solution File (.slnx)
+
+Create `YourSolution.slnx` using the XML-based format:
+
+```xml
+<Solution>
+  <Project Path="src/Domain/Domain.csproj" />
+  <Project Path="src/Domain.SourceGenerators/Domain.SourceGenerators.csproj" />
+  <Project Path="src/Application/Application.csproj" />
+  <Project Path="src/Presentation/Presentation.csproj" />
+  <Project Path="src/Presentation.Cli/Presentation.Cli.csproj" />
+</Solution>
+```
+
+The `.slnx` format is supported since .NET 9.0.200 SDK and Visual Studio 17.13+. It eliminates GUIDs and configuration boilerplate from the old `.sln` format.
+
+---
+
+## Step 6: Create Directory.Build.targets
+
+Create `Directory.Build.targets` at the project root. This file auto-wires the `BuildConstantsGenerator` source generator and embedded config for leaf executable projects:
+
+```xml
+<Project>
+	<PropertyGroup Condition="'$(BaseCommandType)' != ''">
+		<GenerateBuildConstants>true</GenerateBuildConstants>
+	</PropertyGroup>
+
+	<PropertyGroup Condition="'$(GenerateBuildConstants)' == 'true'">
+		<AssemblyName Condition="'$(AssemblyName)' == ''">sampleapp</AssemblyName>
+		<AssemblyTitle Condition="'$(AssemblyTitle)' == ''">Sample Application</AssemblyTitle>
+		<Description Condition="'$(Description)' == ''">Sample Application</Description>
+		<FullVersion Condition="'$(FullVersion)' == ''">0.0.0-prerelease.0+build.local</FullVersion>
+		<InformationalVersion Condition="'$(InformationalVersion)' == ''">$(FullVersion)</InformationalVersion>
+		<AppTag Condition="'$(AppTag)' == ''">prerelease</AppTag>
+		<EmbeddedConfigFileName Condition="'$(EmbeddedConfigFileName)' == ''">embedded-config.json</EmbeddedConfigFileName>
+		<EmbeddedConfigPath Condition="'$(EmbeddedConfigPath)' == ''">$(MSBuildThisFileDirectory)$(EmbeddedConfigFileName)</EmbeddedConfigPath>
+		<BaseCommandType Condition="'$(BaseCommandType)' == ''"></BaseCommandType>
+	</PropertyGroup>
+
+	<ItemGroup Condition="'$(GenerateBuildConstants)' == 'true'">
+		<ProjectReference Include="$(MSBuildThisFileDirectory)src\Domain.SourceGenerators\Domain.SourceGenerators.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
+		<AdditionalFiles Include="$(EmbeddedConfigPath)" />
+		<CompilerVisibleProperty Include="GenerateBuildConstants" />
+		<CompilerVisibleProperty Include="BaseCommandType" />
+		<CompilerVisibleProperty Include="AssemblyName" />
+		<CompilerVisibleProperty Include="AssemblyTitle" />
+		<CompilerVisibleProperty Include="Description" />
+		<CompilerVisibleProperty Include="FullVersion" />
+		<CompilerVisibleProperty Include="AppTag" />
+		<CompilerVisibleProperty Include="EmbeddedConfigFileName" />
+	</ItemGroup>
+</Project>
+```
+
+---
+
+## Step 7: Create the Domain Layer
+
+### Domain.csproj
+
+```xml
+<Project Sdk="Microsoft.NET.Sdk">
+
+	<ItemGroup>
+		<PackageReference Include="ApplicationBuilderHelpers" Version="4.1.86" />
+		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.9" />
+	</ItemGroup>
+
+	<ItemGroup>
+		<ProjectReference Include="..\Domain.SourceGenerators\Domain.SourceGenerators.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
+	</ItemGroup>
+
+</Project>
+```
+
+### Domain.cs (ApplicationDependency)
+
+The Domain ApplicationDependency registers shared and feature services:
+
+```csharp
+using ApplicationBuilderHelpers;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Domain;
+
+public class Domain : ApplicationDependency
+{
+    public override void AddServices(ApplicationHostBuilder applicationBuilder, IServiceCollection services)
+    {
+        base.AddServices(applicationBuilder, services);
+
+        // Register shared domain services and feature services
+        services.AddSharedServices();
+        // services.Add{Feature}Services();
+    }
+}
+```
+
+### Domain/Shared/Interfaces/ (Base Contracts)
+
+Create the marker interfaces in `Domain/Shared/Interfaces/`:
+
+```csharp
+// IEntity.cs
+namespace Domain.Shared.Interfaces;
+
+public interface IEntity;
+
+// IAggregateRoot.cs
+namespace Domain.Shared.Interfaces;
+
+public interface IAggregateRoot;
+
+// IDomainEvent.cs
+namespace Domain.Shared.Interfaces;
+
+public interface IDomainEvent;
+
+// IUnitOfWork.cs
+namespace Domain.Shared.Interfaces;
+
+public interface IUnitOfWork
+{
+    Task CommitAsync(CancellationToken cancellationToken = default);
+}
+```
+
+### Domain/Shared/Models/ (Base Classes)
+
+Create the base model classes per the architecture rules. Use `protected` constructors and static factory methods for Entities and ValueObjects.
+
+### Domain/Shared/Extensions/SharedServiceCollectionExtensions.cs
+
+```csharp
+namespace Domain.Shared.Extensions;
+
+public static class SharedServiceCollectionExtensions
+{
+    internal static IServiceCollection AddSharedServices(this IServiceCollection services)
+    {
+        return services;
+    }
+}
+```
+
+---
+
+## Step 8: Create the Domain.SourceGenerators Project
+
+```xml
+<Project Sdk="Microsoft.NET.Sdk">
+
+	<PropertyGroup>
+		<TargetFramework>netstandard2.0</TargetFramework>
+		<EnforceExtendedAnalyzerRules>true</EnforceExtendedAnalyzerRules>
+	</PropertyGroup>
+
+	<ItemGroup>
+		<PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.14.0" PrivateAssets="all" />
+	</ItemGroup>
+
+</Project>
+```
+
+Copy the `BuildConstantsGenerator` from the template's `src/Domain.SourceGenerators/Generators/` directory. This source generator creates `Build.Constants`, `Build.ApplicationConstants`, and `Build.BaseCommand<T>` at compile time.
+
+---
+
+## Step 9: Create the Application Layer
+
+### Application.csproj
+
+```xml
+<Project Sdk="Microsoft.NET.Sdk">
+
+	<ItemGroup>
+		<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.9" />
+		<PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.9" />
+	</ItemGroup>
+
+	<ItemGroup>
+		<ProjectReference Include="..\Domain\Domain.csproj" />
+	</ItemGroup>
+
+</Project>
+```
+
+### Application.cs (ApplicationDependency)
+
+```csharp
+using Application.Shared.Extensions;
+using ApplicationBuilderHelpers;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Application;
+
+public class Application : ApplicationDependency
+{
+    public override void AddServices(ApplicationHostBuilder applicationBuilder, IServiceCollection services)
+    {
+        base.AddServices(applicationBuilder, services);
+
+        services.AddSharedServices();
+        // services.Add{Feature}Services();
+    }
+}
+```
+
+### Application/Shared/Extensions/SharedServiceCollectionExtensions.cs
+
+```csharp
+namespace Application.Shared.Extensions;
+
+public static class SharedServiceCollectionExtensions
+{
+    internal static IServiceCollection AddSharedServices(this IServiceCollection services)
+    {
+        services.AddScoped<IDomainEventDispatcher, DomainEventDispatcher>();
+        return services;
+    }
+}
+```
+
+---
+
+## Step 10: Create the Presentation Layer
+
+### Presentation.csproj
+
+```xml
+<Project Sdk="Microsoft.NET.Sdk">
+
+	<ItemGroup>
+		<ProjectReference Include="..\Application\Application.csproj" />
+	</ItemGroup>
+
+</Project>
+```
+
+### Presentation/Commands/BaseCommand.cs
+
+The base command wires configuration, logging, and the application banner:
+
+```csharp
+using Application.Logger.Extensions;
+using ApplicationBuilderHelpers;
+using ApplicationBuilderHelpers.Attributes;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using System.Diagnostics.CodeAnalysis;
+
+namespace Presentation.Commands;
+
+public abstract class BaseCommand<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] THostApplicationBuilder> : Command<THostApplicationBuilder>
+    where THostApplicationBuilder : IHostApplicationBuilder
+{
+    public abstract IApplicationConstants ApplicationConstants { get; }
+
+    [CommandOption(
+        'l', "log-level",
+        EnvironmentVariable = "LOG_LEVEL",
+        Description = "Level of logs to show.")]
+    public LogLevel LogLevel { get; set; } = LogLevel.Information;
+
+    public override void AddConfigurations(ApplicationHostBuilder applicationBuilder, IConfiguration configuration)
+    {
+        base.AddConfigurations(applicationBuilder, configuration);
+        configuration.LoggerLevel = LogLevel;
+    }
+
+    public override void AddServices(ApplicationHostBuilder applicationBuilder, IServiceCollection services)
+    {
+        services.AddSingleton(ApplicationConstants);
+        services.Configure<ConsoleLifetimeOptions>(opts => opts.SuppressStatusMessages = true);
+
+        services.AddLogging(builder =>
+        {
+            builder.SetMinimumLevel(applicationBuilder.Configuration.LoggerLevel);
+            builder.AddConsole();
+        });
+
+        base.AddServices(applicationBuilder, services);
+    }
+
+    protected override async ValueTask Run(ApplicationHost<THostApplicationBuilder> applicationHost, CancellationTokenSource cancellationTokenSource)
+    {
+        using var scope = applicationHost.Services.CreateScope();
+        var logger = scope.ServiceProvider.GetRequiredService<ILogger<BaseCommand<THostApplicationBuilder>>>();
+        logger.LogInformation("Application started: {AppName} v{Version}", ApplicationConstants.AppName, ApplicationConstants.Version);
+    }
+
+    private static string BuildAppBanner()
+    {
+        // Application banner display
+        return "Application Banner";
+    }
+}
+```
+
+---
+
+## Step 11: Create the Composition Root (Presentation.Cli)
+
+### Presentation.Cli.csproj
+
+```xml
+<Project Sdk="Microsoft.NET.Sdk">
+
+	<PropertyGroup>
+		<BaseCommandType>Presentation.Commands.BaseCommand</BaseCommandType>
+		<OutputType>Exe</OutputType>
+	</PropertyGroup>
+
+	<PropertyGroup>
+		<AssemblyName>myapp</AssemblyName>
+		<AssemblyTitle>My Application</AssemblyTitle>
+		<Description>My CLI application.</Description>
+	</PropertyGroup>
+
+	<ItemGroup>
+		<ProjectReference Include="..\Application\Application.csproj" />
+		<ProjectReference Include="..\Infrastructure.InMemory\Infrastructure.InMemory.csproj" />
+		<ProjectReference Include="..\Presentation\Presentation.csproj" />
+	</ItemGroup>
+
+</Project>
+```
+
+Setting `BaseCommandType` to `Presentation.Commands.BaseCommand` automatically enables `GenerateBuildConstants` in `Directory.Build.targets`, which generates `Build.BaseCommand<T>`.
+
+### Presentation.Cli/Commands/MainCommand.cs
+
+```csharp
+using ApplicationBuilderHelpers;
+using ApplicationBuilderHelpers.Attributes;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace Presentation.Cli.Commands;
+
+[Command("Main subcommand.")]
+internal class MainCommand : Build.BaseCommand<HostApplicationBuilder>
+{
+    protected override ValueTask<HostApplicationBuilder> ApplicationBuilder(CancellationToken stoppingToken)
+    {
+        var builder = Host.CreateApplicationBuilder();
+        return new ValueTask<HostApplicationBuilder>(builder);
+    }
+
+    protected override async ValueTask Run(ApplicationHost<HostApplicationBuilder> applicationHost, CancellationTokenSource cancellationTokenSource)
+    {
+        await base.Run(applicationHost, cancellationTokenSource);
+
+        using var scope = applicationHost.Services.CreateScope();
+        var logger = scope.ServiceProvider.GetRequiredService<ILogger<MainCommand>>();
+
+        logger.LogInformation("Hello from MainCommand!");
+
+        // Signal completion for one-shot CLI commands
+        cancellationTokenSource.Cancel();
+    }
+}
+```
+
+### Presentation.Cli/Program.cs
+
+`Program.cs` is the ONLY file permitted to import from `Infrastructure.*`:
+
+```csharp
+using Infrastructure.InMemory;
+using Presentation.Cli.Commands;
+
+return await ApplicationBuilderHelpers.ApplicationBuilder.Create()
+    .AddApplication<Domain.Domain>()
+    .AddApplication<Application.Application>()
+    .AddApplication<InMemoryInfrastructure>()
+    .AddCommand<MainCommand>()
+    .RunAsync(args);
+```
+
+---
+
+## Step 12: Create the Infrastructure Layer
+
+Only create Infrastructure when you need data access or external service calls. For an in-memory starter:
+
+```csharp
+// Infrastructure.InMemory/InMemoryInfrastructure.cs
+using ApplicationBuilderHelpers;
+using Infrastructure.InMemory.Extensions;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Infrastructure.InMemory;
+
+public class InMemoryInfrastructure : ApplicationDependency
+{
+    public override void AddServices(ApplicationHostBuilder applicationBuilder, IServiceCollection services)
+    {
+        base.AddServices(applicationBuilder, services);
+        services.AddInMemoryServices();
+    }
+}
+```
+
+Per the architecture rules:
+- ApplicationDependency MUST extend `ApplicationDependency` directly
+- ApplicationDependency MUST register services through ServiceCollectionExtensions
+- ApplicationDependency MUST call `base.Method()` in all lifecycle method overrides
+
+---
+
+## Step 13: Create embedded-config.json
+
+Create `embedded-config.json` at the solution root for build-time encrypted configuration:
+
+```json
+{
+    "shared_config": {},
+    "environment_config": {}
+}
+```
+
+Generate the encrypted version:
+
+```bash
+dotnet build src/Presentation.Cli
+```
+
+This file is read by `Directory.Build.targets` as an MSBuild `AdditionalFiles` item, and the `BuildConstantsGenerator` source generator bakes the contents into `Build.ApplicationConstants`.
+
+---
+
+## Step 14: Verify the Setup
+
+The project structure MUST look like this:
+
+```
+<project_root>/
+├── .github/
+│   └── instructions/
+│       ├── agent-terminal.instructions.md
+│       ├── architecture.instructions.md
+│       ├── code-quality.instructions.md
+│       ├── documentation.instructions.md
+│       ├── project-context.instructions.md
+│       ├── rule-style.instructions.md
+│       ├── ui-test-practices.instructions.md
+│       └── workflow.instructions.md
+├── AGENTS.md
+├── src/
+│   ├── Domain/
+│   │   ├── Domain.cs
+│   │   ├── Domain.csproj
+│   │   └── Shared/
+│   ├── Domain.SourceGenerators/
+│   │   └── Domain.SourceGenerators.csproj
+│   ├── Application/
+│   │   ├── Application.cs
+│   │   ├── Application.csproj
+│   │   └── Shared/
+│   ├── Infrastructure.InMemory/
+│   │   ├── InMemoryInfrastructure.cs
+│   │   └── Infrastructure.InMemory.csproj
+│   ├── Presentation/
+│   │   ├── Presentation.csproj
+│   │   └── Commands/
+│   │       └── BaseCommand.cs
+│   └── Presentation.Cli/
+│       ├── Presentation.Cli.csproj
+│       ├── Program.cs
+│       └── Commands/
+│           └── MainCommand.cs
+├── tests/
+├── Directory.Build.targets
+├── embedded-config.json
+├── global.json
+└── YourSolution.slnx
+```
+
+Build and run:
+
+```bash
+dotnet build
+```
+
+```bash
+dotnet run --project src/Presentation.Cli
+```
+
+Expected: the application starts, displays the app banner, logs startup information, and exits.
+
+---
+
+## Step 15: Pre-Commit Verification
+
+Per `workflow.instructions.md`:
+
+```bash
+dotnet build
+```
+
+MUST complete with 0 warnings and 0 errors.
+
+```bash
+dotnet test
+```
+
+MUST pass 100%.
+
+---
+
+## Reminder: Rules Take Precedence
+
+When adding any feature beyond this scaffold, MUST consult the rules in `.github/instructions/` first. The architecture rules govern:
+
+- Where each type of file lives (entities, value objects, services, adapters, etc.)
+- Which layer may reference which other layer (Domain→nothing, Application→Domain, Infrastructure→Domain+Application, Presentation→Domain+Application)
+- Which lifetime each service uses (Domain services: Singleton, Application services: typically Scoped)
+- Where interfaces live (Inbound, Outbound, or internal)
+- Naming conventions for types, files, and namespaces
+- Prohibited patterns that MUST NEVER be introduced
+
+Do not improvise structure. The rules are the contract.

--- a/AGENT_RESUME.md
+++ b/AGENT_RESUME.md
@@ -1,0 +1,679 @@
+# Convert Existing C# Project to ApplicationBuilderHelpers
+
+You are converting an existing C# project to use the **ApplicationBuilderHelpers** framework — a dependency injection and application lifecycle framework built on clean architecture principles. It provides `ApplicationDependency` lifecycle management, command hierarchy with CLI option parsing, multi-source configuration with `@ref:` chains, build-time encrypted embedded config, source-generated build constants, structured logging, and a middleware pipeline.
+
+Refer to the [ApplicationBuilderHelpers](https://github.com/nicenemo/ApplicationBuilderHelpers) repository for the NuGet package and core documentation. Use [ApplicationBuilderHelpersTemplate](https://github.com/Kiryuumaru/ApplicationBuilderHelpersTemplate) as the reference implementation.
+
+---
+
+## Step 1: Install the Rules and Documentation First
+
+Before changing any existing file, install the project's rule set. These rules determine how to refactor the existing code into the layered architecture. Every step that follows depends on them.
+
+Clone the template repository into a temporary directory:
+
+```bash
+git clone https://github.com/Kiryuumaru/ApplicationBuilderHelpersTemplate.git /tmp/abht_source
+```
+
+Copy the agent instruction files into the project:
+
+```bash
+mkdir -p .github/instructions
+cp /tmp/abht_source/.github/instructions/*.md .github/instructions/
+```
+
+Copy the AGENTS.md into the project:
+
+```bash
+cp /tmp/abht_source/AGENTS.md .
+```
+
+---
+
+## Step 2: Read All Rules End-to-End
+
+Read every file in `.github/instructions/` before refactoring any code. Treat them as MUST/NEVER constraints, not suggestions:
+
+- `project-context.instructions.md` — terminology, project status (this project is unreleased; refactor freely), breaking-change policy
+- `rule-style.instructions.md` — how rules are written
+- `architecture.instructions.md` — layering, folder structure, DI lifetimes, ports/adapters, ApplicationDependency, ServiceCollectionExtensions, ConfigurationExtensions, commands, workers, naming, prohibited patterns
+- `code-quality.instructions.md` — nullable handling, commenting, constructors, fix hygiene
+- `documentation.instructions.md` — when to update docs
+- `workflow.instructions.md` — build/test commands, pre-commit checks
+- `agent-terminal.instructions.md` — terminal usage rules (no `&&`, `|`, `;`, redirections)
+- `ui-test-practices.instructions.md` — test conventions, assertions, no `Task.Delay`
+
+---
+
+## Step 3: Audit the Existing Project Against the Rules
+
+Map the existing code to the rules from Step 2. Produce an audit before changing anything:
+
+1. **Identify the entry point** — This becomes the composition root in `Presentation.Cli/Program.cs`. Look for `Main()` methods, top-level statements, `Program.cs`, or the application startup logic.
+
+2. **Identify each existing type** and classify it per the `architecture.instructions.md` File Placement table:
+
+   | Current Type | Layer | Target Location |
+   |-------------|-------|-----------------|
+   | Entities with identity | Domain | `Domain/{Feature}/Entities/` |
+   | Immutable value types | Domain | `Domain/{Feature}/ValueObjects/` |
+   | Pure business logic (no I/O) | Domain | `Domain/{Feature}/Services/` |
+   | Data transfer objects | Domain | `Domain/{Feature}/Models/` |
+   | Enumerations | Domain | `Domain/{Feature}/Enums/` |
+   | Orchestration with I/O | Application | `Application/{Feature}/Services/` |
+   | Inbound port interfaces | Application | `Application/{Feature}/Interfaces/Inbound/` |
+   | Outbound port interfaces | Application | `Application/{Feature}/Interfaces/Outbound/` |
+   | Background tasks | Application | `Application/{Feature}/Workers/` |
+   | Database/HTTP adapters | Infrastructure | `Infrastructure.{Provider}/Adapters/` |
+   | Repositories | Infrastructure | `Infrastructure.{Provider}.{Feature}/Repositories/` |
+   | CLI/HTTP entry points | Presentation | `Presentation.Cli/Commands/` |
+
+3. **For each type identified, record:**
+   - Which dependencies it needs (these become constructor parameters)
+   - Whether an interface exists (if not, one MUST be created per the interface placement rules)
+   - Required lifetime per "Dependency Injection Lifetime Rules" (Singleton/Scoped/Transient)
+
+4. **Identify configuration sources** (hardcoded strings, appsettings.json, env vars, custom parsers) — all consolidate through `IConfiguration` with ConfigurationExtensions per the rules.
+
+5. **Identify background tasks, timers, and polling loops** — these become `BackgroundService` workers in `Application/{Feature}/Workers/`.
+
+6. **Identify logging** (`Console.WriteLine`, `ILogger<T>` scattered across layers) — all consolidate through `ILogger<T>` injected via constructor.
+
+---
+
+## Step 4: Plan the Target Structure From the Rules
+
+Using the audit and the rules, design the target layout. The architecture rules require:
+
+```
+src/
+├── Domain/
+│   ├── Domain.cs                    <- ApplicationDependency
+│   ├── Domain.csproj
+│   ├── Serialization/
+│   ├── Shared/
+│   │   ├── Interfaces/              <- IUnitOfWork, IAggregateRoot, IDomainEvent, IEntity
+│   │   ├── Models/                  <- Entity, AggregateRoot, ValueObject, DomainEvent
+│   │   ├── Exceptions/              <- DomainException, EntityNotFoundException, ValidationException
+│   │   ├── Constants/               <- EmptyCollections, shared constants
+│   │   └── Extensions/
+│   └── {Feature}/
+│       ├── Entities/
+│       ├── ValueObjects/
+│       ├── Models/
+│       ├── Interfaces/              <- I{Feature}Repository, I{Feature}UnitOfWork
+│       ├── Services/                <- pure domain services
+│       ├── Events/
+│       ├── Exceptions/
+│       ├── Constants/
+│       └── Extensions/
+├── Domain.SourceGenerators/
+│   └── Domain.SourceGenerators.csproj
+├── Application/
+│   ├── Application.cs               <- ApplicationDependency
+│   ├── Application.csproj
+│   ├── Serialization/
+│   ├── Shared/
+│   │   ├── Interfaces/              <- IDomainEventDispatcher, IDomainEventHandler
+│   │   ├── Interfaces/Inbound/
+│   │   ├── Interfaces/Outbound/
+│   │   ├── Models/
+│   │   ├── Services/
+│   │   └── Extensions/
+│   └── {Feature}/
+│       ├── Interfaces/
+│       │   ├── Inbound/             <- I{Feature}Service (called by Presentation)
+│       │   └── Outbound/            <- I{External}Provider (called by Application)
+│       ├── Services/
+│       ├── Workers/
+│       ├── EventHandlers/
+│       ├── Models/
+│       ├── Validators/
+│       └── Extensions/
+├── Infrastructure.{Provider}/
+│   ├── {Provider}Infrastructure.cs   <- ApplicationDependency
+│   ├── {Provider}.Infrastructure.csproj
+│   ├── Adapters/
+│   ├── Repositories/
+│   ├── Configurations/
+│   └── Extensions/
+├── Infrastructure.{Provider}.{Feature}/
+│   ├── Adapters/
+│   ├── Repositories/
+│   └── Extensions/
+├── Presentation/
+│   ├── Presentation.csproj
+│   └── Commands/
+│       └── BaseCommand.cs
+└── Presentation.Cli/
+    ├── Presentation.Cli.csproj
+    ├── Program.cs                    <- ONLY file that imports from Infrastructure
+    └── Commands/
+        └── MainCommand.cs
+```
+
+Each layer has an `ApplicationDependency` at its root that registers services via `ServiceCollectionExtensions`. `Presentation.Cli/Program.cs` calls `.AddApplication<T>()` for each layer in dependency order.
+
+---
+
+## Step 5: Add the ApplicationBuilderHelpers NuGet Package
+
+Ensure `ApplicationBuilderHelpers` is referenced in `Domain.csproj` (all layers inherit this transitively through Domain):
+
+```xml
+<PackageReference Include="ApplicationBuilderHelpers" Version="4.1.86" />
+```
+
+Check the latest version on [NuGet](https://www.nuget.org/packages/ApplicationBuilderHelpers) and update accordingly.
+
+Ensure the `TargetFramework` is set. For new projects, use `net10.0`:
+
+```xml
+<PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+</PropertyGroup>
+```
+
+---
+
+## Step 6: Set Up Directory.Build.targets and global.json
+
+Copy `Directory.Build.targets` from the template to the project root. This file auto-wires:
+- `BuildConstantsGenerator` source generator (build constants, `Build.BaseCommand<T>`)
+- `embedded-config.json` as an MSBuild AdditionalFile
+- MSBuild properties exposed to the source generator
+
+Create or update `global.json` to pin the SDK version:
+
+```json
+{
+  "sdk": {
+    "version": "10.0.300",
+    "rollForward": "latestFeature"
+  }
+}
+```
+
+Create the solution file in `.slnx` format if not already present:
+
+```bash
+dotnet new slnx
+```
+
+Or write it manually:
+
+```xml
+<Solution>
+  <Project Path="src/Domain/Domain.csproj" />
+  <Project Path="src/Domain.SourceGenerators/Domain.SourceGenerators.csproj" />
+  <Project Path="src/Application/Application.csproj" />
+  <Project Path="src/Presentation/Presentation.csproj" />
+  <Project Path="src/Presentation.Cli/Presentation.Cli.csproj" />
+</Solution>
+```
+
+---
+
+## Step 7: Define Interfaces Before Refactoring Implementations
+
+For each cross-layer dependency identified in Step 3, create an interface in the correct location per the rules:
+
+| Interface Type | Location | Implemented By |
+|---------------|----------|---------------|
+| Repository | `Domain/{Feature}/Interfaces/I{Feature}Repository.cs` | Infrastructure |
+| Unit of Work | `Domain/{Feature}/Interfaces/I{Feature}UnitOfWork.cs` | Infrastructure |
+| Inbound Service | `Application/{Feature}/Interfaces/Inbound/I{Feature}Service.cs` | Application |
+| Outbound Provider | `Application/{Feature}/Interfaces/Outbound/I{Provider}.cs` | Infrastructure |
+| Internal | `Application/{Feature}/Interfaces/` | Application |
+
+Interface rules:
+- MUST be `public` (used across layers)
+- MUST be one type per file
+- MUST follow `I{PascalCase}` naming
+- Inbound interfaces MAY be called by any layer
+- Outbound interfaces MUST NOT be called by Presentation
+- Internal interfaces MUST NOT be called by Presentation
+
+Update each implementation to:
+- Implement its interface
+- Accept dependencies via constructor injection (use primary constructors when only storing)
+- Drop manual instantiation of dependencies — the DI container resolves them
+- Be `internal` (resolved via DI, not constructed directly)
+
+```csharp
+// Before
+public class EmailService
+{
+    private readonly SmtpClient _client = new();
+    public void Send(string to, string body) { ... }
+}
+
+// After — interface in Application/{Feature}/Interfaces/Outbound/
+public interface IEmailSender
+{
+    Task SendAsync(string to, string body, CancellationToken cancellationToken);
+}
+
+// After — implementation in Infrastructure.Email/
+internal sealed class SmtpEmailSender(IEmailConfiguration config) : IEmailSender
+{
+    public async Task SendAsync(string to, string body, CancellationToken cancellationToken)
+    {
+        ...
+    }
+}
+```
+
+---
+
+## Step 8: Create the ApplicationDependency Classes
+
+Every layer (except Presentation) MUST have an `ApplicationDependency` implementation at its project root. These orchestrate DI registration:
+
+```csharp
+// src/Domain/Domain.cs
+namespace Domain;
+
+public class Domain : ApplicationDependency
+{
+    public override void AddServices(ApplicationHostBuilder applicationBuilder, IServiceCollection services)
+    {
+        base.AddServices(applicationBuilder, services);
+        services.AddSharedServices();
+        // services.Add{Feature}Services();
+    }
+}
+```
+
+```csharp
+// src/Application/Application.cs
+namespace Application;
+
+public class Application : ApplicationDependency
+{
+    public override void AddServices(ApplicationHostBuilder applicationBuilder, IServiceCollection services)
+    {
+        base.AddServices(applicationBuilder, services);
+        services.AddSharedServices();
+        // services.Add{Feature}Services();
+    }
+}
+```
+
+```csharp
+// src/Infrastructure.InMemory/InMemoryInfrastructure.cs
+namespace Infrastructure.InMemory;
+
+public class InMemoryInfrastructure : ApplicationDependency
+{
+    public override void AddServices(ApplicationHostBuilder applicationBuilder, IServiceCollection services)
+    {
+        base.AddServices(applicationBuilder, services);
+        services.AddInMemoryServices();
+    }
+}
+```
+
+ApplicationDependency rules:
+- MUST extend `ApplicationDependency` directly
+- MUST NOT extend another ApplicationDependency implementation
+- MUST register services through ServiceCollectionExtensions
+- MUST call `base.Method()` in all lifecycle method overrides
+
+---
+
+## Step 9: Create ServiceCollectionExtensions
+
+For every feature and shared folder, create a corresponding ServiceCollectionExtensions class:
+
+```csharp
+// Domain/Shared/Extensions/SharedServiceCollectionExtensions.cs
+namespace Domain.Shared.Extensions;
+
+public static class SharedServiceCollectionExtensions
+{
+    internal static IServiceCollection AddSharedServices(this IServiceCollection services)
+    {
+        return services;
+    }
+}
+```
+
+```csharp
+// Application/Shared/Extensions/SharedServiceCollectionExtensions.cs
+namespace Application.Shared.Extensions;
+
+public static class SharedServiceCollectionExtensions
+{
+    internal static IServiceCollection AddSharedServices(this IServiceCollection services)
+    {
+        services.AddScoped<IDomainEventDispatcher, DomainEventDispatcher>();
+        return services;
+    }
+}
+```
+
+ServiceCollectionExtensions rules:
+- MUST be `internal static` when called only by same-layer ApplicationDependency
+- MAY be `public static` when designed for cross-layer use
+- MUST have methods named `Add{Feature}Services`
+- MUST be one class per feature
+
+---
+
+## Step 10: Convert Configuration to IConfiguration + ConfigurationExtensions
+
+Replace hardcoded values, scattered `appsettings.json` reads, and environment variable access. Create ConfigurationExtensions per the rules:
+
+```csharp
+// Application/Logger/Extensions/LoggerConfigurationExtensions.cs
+namespace Application.Logger.Extensions;
+
+public static class LoggerConfigurationExtensions
+{
+    private const string LoggerLevelKey = "RUNTIME_LOGGER_LEVEL";
+
+    extension(IConfiguration configuration)
+    {
+        public LogLevel LoggerLevel
+        {
+            get
+            {
+                var loggerLevel = configuration.GetRefValueOrDefault(LoggerLevelKey, LogLevel.Information.ToString());
+                return Enum.Parse<LogLevel>(loggerLevel);
+            }
+            set => configuration[LoggerLevelKey] = value.ToString();
+        }
+    }
+}
+```
+
+ConfigurationExtension rules:
+- MUST use `extension(IConfiguration)` block (C# 13+) or `this IConfiguration` syntax
+- MUST use private const string for key names
+- MUST have property with getter and setter
+- MUST use `GetRefValueOrDefault` for reference chain support
+
+Consolidate all configuration access through these extensions. Presentation sets values (from CLI options, env vars), Application and Infrastructure read them.
+
+---
+
+## Step 11: Convert Background Tasks to Workers
+
+Replace `Task.Run()`, `Timer`, `PeriodicTimer`, and `while(true)` loops with `BackgroundService` implementations in the Application layer:
+
+```csharp
+// Application/{Feature}/Workers/ItemProcessor.cs
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace Application.Feature.Workers;
+
+internal sealed class ItemProcessor(IServiceScopeFactory scopeFactory, ILogger<ItemProcessor> logger) : BackgroundService
+{
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            await using var scope = scopeFactory.CreateAsyncScope();
+            // Resolve services and do work
+            await Task.Delay(TimeSpan.FromSeconds(30), stoppingToken);
+        }
+    }
+}
+```
+
+Worker rules:
+- MUST be `internal` classes (not injectable, resolved as hosted services)
+- MUST extend `BackgroundService`
+- MUST live in `Application/{Feature}/Workers/`
+- MUST create scopes to resolve Scoped services
+- MUST NOT be injected into other services
+
+---
+
+## Step 12: Convert Logging to ILogger\<T\>
+
+Replace `Console.WriteLine()`, direct `ILoggerFactory` usage, and static loggers. Inject `ILogger<T>` via constructor:
+
+```csharp
+// Before
+Console.WriteLine($"Processing order {orderId}");
+
+// After — inject ILogger<OrderService>
+internal sealed class OrderService(ILogger<OrderService> logger) : IOrderService
+{
+    public async Task ProcessAsync(Guid orderId, CancellationToken cancellationToken)
+    {
+        logger.LogInformation("Processing order {OrderId}", orderId);
+    }
+}
+```
+
+Logging rules:
+- MUST inject `ILogger<T>` via constructor, never create at static scope
+- MUST use structured logging with named placeholders
+- MUST NOT log sensitive data (API keys, passwords, tokens)
+
+---
+
+## Step 13: Create the Presentation Layer
+
+### Presentation/Commands/BaseCommand.cs
+
+Create a shared base command that all leaf commands extend:
+
+```csharp
+using Application.Logger.Extensions;
+using ApplicationBuilderHelpers;
+using ApplicationBuilderHelpers.Attributes;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using System.Diagnostics.CodeAnalysis;
+
+namespace Presentation.Commands;
+
+public abstract class BaseCommand<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] THostApplicationBuilder> : Command<THostApplicationBuilder>
+    where THostApplicationBuilder : IHostApplicationBuilder
+{
+    public abstract IApplicationConstants ApplicationConstants { get; }
+
+    [CommandOption('l', "log-level", EnvironmentVariable = "LOG_LEVEL", Description = "Level of logs to show.")]
+    public LogLevel LogLevel { get; set; } = LogLevel.Information;
+
+    public override void AddConfigurations(ApplicationHostBuilder applicationBuilder, IConfiguration configuration)
+    {
+        base.AddConfigurations(applicationBuilder, configuration);
+        configuration.LoggerLevel = LogLevel;
+    }
+
+    public override void AddServices(ApplicationHostBuilder applicationBuilder, IServiceCollection services)
+    {
+        services.AddSingleton(ApplicationConstants);
+        services.Configure<ConsoleLifetimeOptions>(opts => opts.SuppressStatusMessages = true);
+
+        services.AddLogging(builder =>
+        {
+            builder.SetMinimumLevel(applicationBuilder.Configuration.LoggerLevel);
+            builder.AddConsole();
+        });
+
+        base.AddServices(applicationBuilder, services);
+    }
+}
+```
+
+---
+
+## Step 14: Wire the Composition Root
+
+### Presentation.Cli/Program.cs
+
+`Program.cs` is the ONLY file permitted to import from `Infrastructure.*`:
+
+```csharp
+using Infrastructure.InMemory;
+using Presentation.Cli.Commands;
+
+return await ApplicationBuilderHelpers.ApplicationBuilder.Create()
+    .AddApplication<Domain.Domain>()
+    .AddApplication<Application.Application>()
+    .AddApplication<InMemoryInfrastructure>()
+    .AddCommand<MainCommand>()
+    .RunAsync(args);
+```
+
+Layer registration order MUST be: Domain → Application → Infrastructure → Commands.
+
+### Presentation.Cli/Commands/MainCommand.cs
+
+Move the existing entry point logic into a command:
+
+```csharp
+[Command("Main subcommand.")]
+internal class MainCommand : Build.BaseCommand<HostApplicationBuilder>
+{
+    protected override ValueTask<HostApplicationBuilder> ApplicationBuilder(CancellationToken stoppingToken)
+    {
+        var builder = Host.CreateApplicationBuilder();
+        return new ValueTask<HostApplicationBuilder>(builder);
+    }
+
+    protected override async ValueTask Run(ApplicationHost<HostApplicationBuilder> applicationHost, CancellationTokenSource cancellationTokenSource)
+    {
+        await base.Run(applicationHost, cancellationTokenSource);
+
+        using var scope = applicationHost.Services.CreateScope();
+        // Resolve services and perform work
+
+        cancellationTokenSource.Cancel(); // Signal completion for one-shot commands
+    }
+}
+```
+
+### Presentation.Cli.csproj
+
+```xml
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <BaseCommandType>Presentation.Commands.BaseCommand</BaseCommandType>
+        <OutputType>Exe</OutputType>
+    </PropertyGroup>
+
+    <PropertyGroup>
+        <AssemblyName>myapp</AssemblyName>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="..\Application\Application.csproj" />
+        <ProjectReference Include="..\Infrastructure.InMemory\Infrastructure.InMemory.csproj" />
+        <ProjectReference Include="..\Presentation\Presentation.csproj" />
+    </ItemGroup>
+
+</Project>
+```
+
+---
+
+## Step 15: Convert the Solution to .slnx Format
+
+If the project uses the old `.sln` format, convert to `.slnx`:
+
+```bash
+dotnet sln migrate
+```
+
+Or create the `.slnx` manually with clean XML structure. The `.slnx` format eliminates GUIDs and configuration platform boilerplate.
+
+---
+
+## Step 16: Verify the Conversion
+
+1. Every layer has an `ApplicationDependency` class at its root
+2. All dependencies are injected via constructor — no manual instantiation remains
+3. All cross-layer dependencies use interfaces in the correct `Interfaces/Inbound/` or `Interfaces/Outbound/` folders
+4. All background tasks use `BackgroundService` (zero `while(true)` outside Workers)
+5. All configuration access goes through `IConfiguration` with ConfigurationExtensions
+6. All logging uses `ILogger<T>`
+7. Only `Presentation.Cli/Program.cs` imports from `Infrastructure.*`
+8. Each layer registers services through ServiceCollectionExtensions, called from ApplicationDependency
+9. `Presentation.Cli.csproj` has `BaseCommandType` set and `OutputType` as `Exe`
+10. The solution uses `.slnx` format
+
+Build:
+
+```bash
+dotnet build
+```
+
+MUST complete with 0 warnings and 0 errors.
+
+Run:
+
+```bash
+dotnet run --project src/Presentation.Cli
+```
+
+Expected: the application starts, logs via `ILogger<T>`, and exits gracefully (with Ctrl+C for long-running commands).
+
+---
+
+## Step 17: Pre-Commit Verification
+
+Per `workflow.instructions.md`:
+
+```bash
+dotnet build
+```
+
+MUST complete with 0 warnings, 0 errors.
+
+```bash
+dotnet test
+```
+
+MUST pass 100%.
+
+---
+
+## Conversion Checklist
+
+- [ ] Agent instruction files copied to `.github/instructions/` (Step 1)
+- [ ] AGENTS.md copied to project root (Step 1)
+- [ ] All rules read end-to-end (Step 2)
+- [ ] Existing code audited and classified by layer (Step 3)
+- [ ] Target structure planned per architecture rules (Step 4)
+- [ ] ApplicationBuilderHelpers NuGet package added (Step 5)
+- [ ] Directory.Build.targets and global.json configured (Step 6)
+- [ ] Interfaces defined for every cross-layer dependency (Step 7)
+- [ ] ApplicationDependency classes created for each layer (Step 8)
+- [ ] ServiceCollectionExtensions created for each feature/shared (Step 9)
+- [ ] Configuration consolidated through IConfiguration + ConfigurationExtensions (Step 10)
+- [ ] Background tasks converted to BackgroundService Workers (Step 11)
+- [ ] Logging consolidated through ILogger\<T\> (Step 12)
+- [ ] BaseCommand created in Presentation layer (Step 13)
+- [ ] Composition root wired in Presentation.Cli/Program.cs (Step 14)
+- [ ] Solution converted to .slnx format (Step 15)
+- [ ] Application builds with 0 warnings (Step 16)
+- [ ] Application starts and exits gracefully (Step 16)
+- [ ] Pre-commit checks pass (Step 17)
+
+---
+
+## Reminder: Rules Take Precedence
+
+The rules in `.github/instructions/` govern every refactor decision:
+
+- Where each type of file lives (entities, value objects, services, adapters, etc.)
+- Which layer may reference which other layer
+- Which lifetime each service uses
+- Where each interface lives (Inbound, Outbound, or internal per feature)
+- Naming conventions for types, files, and namespaces
+- Prohibited patterns that MUST NEVER be introduced (no `using Infrastructure.*` outside Program.cs, no `public set` on entity properties, no I/O in Domain services, etc.)
+
+Do not improvise structure. The rules are the contract.


### PR DESCRIPTION
## Summary

Adds two session guide files adapted from the [python_application_builder](https://github.com/Kiryuumaru/python_application_builder) equivalents, rewritten for C# and the ApplicationBuilderHelpers framework.

### New Files

**AGENT_INIT.md** — 15-step guide for initializing a new C# project:
- Clone template, install rules to .github/instructions/
- Read all architecture/code-quality rules end-to-end
- Plan layered structure (Domain → Application → Infrastructure → Presentation)
- Create global.json, .slnx, Directory.Build.targets
- Create Domain layer with ApplicationDependency, shared interfaces, base models
- Create Domain.SourceGenerators for Build.BaseCommand<T> generation
- Create Application layer with ApplicationDependency, shared services
- Create Presentation layer (BaseCommand with config/logging wiring)
- Create composition root (Program.cs wiring .AddApplication<T>() chain)
- Create Infrastructure layer (InMemory starter)
- Create embedded-config.json, verify build/run, pre-commit checks

**AGENT_RESUME.md** — 17-step guide for converting an existing C# project:
- Audit existing code against architecture rules (classify each type by layer)
- Define interfaces before refactoring implementations
- Create ApplicationDependency classes and ServiceCollectionExtensions per layer
- Convert configuration to IConfiguration + ConfigurationExtensions
- Convert background tasks to BackgroundService workers
- Convert logging to ILogger\<T\>
- Wire composition root in Program.cs
- Includes full conversion checklist

### Modified
- **AGENTS.md** — Added "Session Guides" section linking to both new files